### PR TITLE
docs: add content structure outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Simple full-stack Hello World web application.
 
+## Documentation
+
+Additional project documentation is available in the `docs` directory.
+For an overview of planned site content, see [Content Structure](docs/content-structure.md).
+
 ## Running locally
 
 ```bash

--- a/docs/content-structure.md
+++ b/docs/content-structure.md
@@ -1,0 +1,37 @@
+# Content Structure
+
+This document outlines the planned content categories and sample posts for the project website.
+
+## 1. Journey Logs / Blog Posts
+Regular updates documenting the learning process, challenges, and breakthroughs.
+
+**Example posts:**
+1. *Week 1: Getting Set Up in the Cloud* – Initial environment setup, tools installed, first impressions.
+2. *Week 4: Automating Deployments with Terraform* – Successes and frustrations using IaC for the first time.
+3. *Week 7: Debugging a Multi-Region Failure* – Lessons learned from a difficult outage and how you resolved it.
+
+## 2. Project Breakdowns
+Detailed analyses of cloud solutions, highlighting architecture decisions, trade-offs, and outcomes.
+
+**Example posts:**
+1. *Serverless Data Pipeline on AWS* – Design, implementation, cost, and performance considerations.
+2. *Multi-Tenant Kubernetes Cluster on GKE* – Handling isolation, scaling, and monitoring.
+3. *Edge Computing with Azure IoT* – Architecture and challenges of pushing compute closer to devices.
+
+## 3. Reference Guides
+Reusable knowledge and best practices for future reference.
+
+**Example posts:**
+1. *Terraform Module Template* – Boilerplate with explanations and best practices for team use.
+2. *Cloud Cost Optimization Strategies* – Techniques and tools to keep budgets in check.
+3. *Comparing AWS and GCP IAM Models* – Key differences, use cases, and pitfalls.
+
+## 4. Portfolio / About Page
+A static page introducing who you are, your goals, and how to contact you.
+
+**Sections:**
+- **About Me:** Brief professional background and career goals.
+- **Featured Projects:** Highlights from project breakdowns with links.
+- **Skills & Certifications:** Snapshot of the technical toolkit.
+- **Contact:** Email, LinkedIn, GitHub, etc.
+


### PR DESCRIPTION
## Summary
- add documentation outlining content categories and sample posts
- link documentation from README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e9a9530c8325991890c73afc77fe