### PR TITLE
Add first blog post with typography styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.post-body {
+  @apply prose dark:prose-invert max-w-none;
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,10 +1,17 @@
 import ThemeToggle from '../components/ThemeToggle';
+import Link from 'next/link';
 
 export default function Home() {
   return (
     <main className="min-h-screen flex flex-col items-center justify-center gap-4 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
       <h1 className="text-4xl font-bold">Welcome to FirstProject</h1>
       <p className="text-lg">This Next.js app runs on AWS App Runner.</p>
+      <Link
+        href="/posts/starting-with-the-basics"
+        className="text-blue-600 dark:text-blue-400 underline"
+      >
+        Read our first post
+      </Link>
       <ThemeToggle />
     </main>
   );

--- a/app/posts/page.js
+++ b/app/posts/page.js
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+export default function PostsPage() {
+  return (
+    <main className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 p-4">
+      <h1 className="text-3xl font-bold mb-4">Posts</h1>
+      <ul className="list-disc pl-5 space-y-2">
+        <li>
+          <Link href="/posts/starting-with-the-basics" className="text-blue-600 dark:text-blue-400">
+            Starting with the Basics: What Every AWS Architect Should Know First
+          </Link>
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/app/posts/starting-with-the-basics/page.js
+++ b/app/posts/starting-with-the-basics/page.js
@@ -1,0 +1,67 @@
+import Link from 'next/link';
+
+export default function Post() {
+  return (
+    <main className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 p-4">
+      <article className="post-body">
+        <h1>Starting with the Basics: What Every AWS Architect Should Know First</h1>
+        <p>
+          When you’re just beginning your AWS architecture journey, the sheer number of services and buzzwords can feel overwhelming. But before you dive into Lambda, EKS, or AI/ML offerings, the most important thing you can do is master the basics—the foundations that everything else in AWS rests on. For any cloud architect, those foundations start with networking, IAM, and understanding how AWS organizes accounts at scale.
+        </p>
+        <h2>1. Networking: Your Foundation</h2>
+        <p>
+          In AWS, everything lives inside a Virtual Private Cloud (VPC). Whether you’re running a single EC2 instance, a container cluster, or a multi-tier enterprise app, the VPC dictates how your resources connect to each other and to the outside world.
+        </p>
+        <p><strong>Key things to know:</strong></p>
+        <ul>
+          <li><strong>Subnets</strong> – Private vs. public subnets define whether resources get direct internet access or stay internal.</li>
+          <li><strong>Route tables & gateways</strong> – Internet Gateways, NAT Gateways, and VPC Peering are how you connect workloads to the outside world or across accounts/regions.</li>
+          <li><strong>Security groups & NACLs</strong> – Security groups act as virtual firewalls on your resources; Network ACLs operate at the subnet level. Get these wrong and your workloads don’t talk.</li>
+        </ul>
+        <p>
+          <strong>👉 Pro tip:</strong> Spend time really learning VPC design. Misconfigured networking is one of the top causes of headaches for new architects.
+        </p>
+        <h2>2. IAM: Identity and Access Management</h2>
+        <p>
+          If VPC is the skeleton, IAM is the nervous system. It decides who and what can do anything inside AWS.
+        </p>
+        <ul>
+          <li><strong>Principals</strong> – Can be users, roles, or services.</li>
+          <li><strong>Policies</strong> – JSON documents that allow or deny actions on resources.</li>
+          <li><strong>Least privilege</strong> – Always start with the minimum permissions needed. Overly permissive IAM roles are one of the most common (and dangerous) missteps.</li>
+        </ul>
+        <p>
+          <strong>👉</strong> IAM looks simple, but can become complex fast. My advice? Learn how to write a least-privilege policy by hand before relying on the console “wizards.”
+        </p>
+        <h2>3. Control Tower: Thinking Beyond One Account</h2>
+        <p>
+          As soon as your environment grows beyond a single developer project, you’ll need to think about multi-account strategy. This is where AWS Organizations and Control Tower come in.
+        </p>
+        <ul>
+          <li><strong>Organizations</strong> – Lets you create multiple AWS accounts and apply policies across them.</li>
+          <li><strong>Control Tower</strong> – Provides a blueprint for setting up a secure, governed multi-account environment with guardrails out of the box.</li>
+        </ul>
+        <p>
+          Even if you’re starting small, understanding that AWS expects enterprises to use multiple accounts for isolation (prod vs. dev, workloads vs. shared services) is crucial.
+        </p>
+        <h2>4. Other First Principles Every Architect Should Know</h2>
+        <p>A few more basics worth internalizing right away:</p>
+        <ul>
+          <li><strong>Regions and Availability Zones (AZs)</strong> – Architect for resilience by spreading workloads across AZs.</li>
+          <li><strong>Shared Responsibility Model</strong> – AWS secures the cloud infrastructure; you secure your workloads and data.</li>
+          <li><strong>Tagging strategy</strong> – From day one, use consistent tags for cost allocation, ownership, and automation. You’ll thank yourself later.</li>
+        </ul>
+        <h2>Wrapping Up</h2>
+        <p>
+          Before you worry about Kubernetes, AI, or serverless, start with VPCs, IAM, and Control Tower basics. Think of these as the foundation of your house: if they’re weak, no amount of cool technology on top will stand for long.
+        </p>
+        <p>
+          In the next posts, I’ll dig deeper into each of these areas with hands-on examples and patterns I’ve used in real-world architectures.
+        </p>
+        <p>
+          <Link href="/" className="text-blue-600 dark:text-blue-400">← Back to home</Link>
+        </p>
+      </article>
+    </main>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.16",
         "autoprefixer": "^10.4.16",
         "postcss": "^8.4.31",
         "tailwindcss": "^3.4.4"
@@ -302,6 +303,36 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ansi-regex": {
@@ -950,6 +981,27 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
   },
   "dependencies": {
     "next": "^14.2.5",
+    "next-themes": "^0.2.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "next-themes": "^0.2.1"
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.16",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.4"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,5 +7,5 @@ module.exports = {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/typography')],
 }


### PR DESCRIPTION
## Summary
- enable Tailwind typography plugin and shared post style
- add first AWS architecture basics post and posts listing
- link to the new post from the home page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(prompts for configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0f1b3f9ac8325a15d962fa7b1a8bd